### PR TITLE
Add storage allocation parameters to nc_create

### DIFF
--- a/src/ncdf2.c
+++ b/src/ncdf2.c
@@ -23,6 +23,16 @@ void R_nc4_enddef( int *ncid )
 }
 
 /*********************************************************************/
+void R_nc4__enddef( int *ncid, int *h_minfree, int *v_align, int *v_minfree, int *r_align)
+{
+	int	err;
+	err = nc__enddef(*ncid, *h_minfree, *v_align, *v_minfree, *r_align);
+	if( err != NC_NOERR )
+		Rprintf( "Error in R_nc4__enddef: %s\n",
+			nc_strerror(err) );
+}
+
+/*********************************************************************/
 void R_nc4_sync( int *ncid )
 {
 	int	err;


### PR DESCRIPTION
In NetCDF4 native (C) code, the function `nc_enddef` has a companion function,  [`nc__enddef`](https://www.unidata.ucar.edu/software/netcdf/docs_rc/group__datasets.html#ga5fe4a3fcd6db18d0583ac47f04f7ac60), with 4 additional parameters that control storage allocation. Correctly controlling storage allocation at create time can have [a large impact on the cost of subsequent operations](https://www.unidata.ucar.edu/software/netcdf/docs_rc/file_structure_and_performance.html) such as adding attributes.

This PR adds optional parameters to `nc_create` that the match `nc__enddef` storage allocation parameters and which are (through a couple of intermediary function) passed into it.